### PR TITLE
Reformat code with clang-format (Google style)

### DIFF
--- a/src/Dictionary.cc
+++ b/src/Dictionary.cc
@@ -2,62 +2,59 @@
 
 #include <vector>
 
-Dictionary *Dictionary::instance = nullptr;
+Dictionary* Dictionary::instance = nullptr;
 
-Dictionary::Dictionary() :
-		db("yasa.db") {
-	db.query("CREATE TABLE IF NOT EXISTS positives(word VARCHAR(30));");
-	db.query("CREATE TABLE IF NOT EXISTS negatives(word VARCHAR(30));");
+Dictionary::Dictionary() : db("yasa.db") {
+  db.query("CREATE TABLE IF NOT EXISTS positives(word VARCHAR(30));");
+  db.query("CREATE TABLE IF NOT EXISTS negatives(word VARCHAR(30));");
 }
 
 Dictionary* Dictionary::getInstance() {
-	if (instance == nullptr) {
-		instance = new Dictionary();
-	}
-	return instance;
+  if (instance == nullptr) {
+    instance = new Dictionary();
+  }
+  return instance;
 }
 
 void Dictionary::addWord(std::string word, Sentiment sentiment) {
-	std::string table =
-			sentiment == Sentiment::positive ? "positives" : "negatives";
-	db.query("INSERT INTO " + table + "(word) VALUES('" + word + "');");
+  std::string table =
+      sentiment == Sentiment::positive ? "positives" : "negatives";
+  db.query("INSERT INTO " + table + "(word) VALUES('" + word + "');");
 }
 
-int Dictionary::size() {
-	return positivesCount() + negativesCount();
-}
+int Dictionary::size() { return positivesCount() + negativesCount(); }
 
 void Dictionary::reset() {
-	db.query("DELETE FROM positives;"
-			"DELETE FROM negatives;"
-			"VACUUM;");
+  db.query(
+      "DELETE FROM positives;"
+      "DELETE FROM negatives;"
+      "VACUUM;");
 }
 
 int Dictionary::positivesCount() {
-	SqliteYasa::QueryResult queryResult = db.query(
-			"SELECT COUNT(*) AS positives_count FROM positives;");
-	return std::stoi(queryResult["positives_count"].front());
+  SqliteYasa::QueryResult queryResult =
+      db.query("SELECT COUNT(*) AS positives_count FROM positives;");
+  return std::stoi(queryResult["positives_count"].front());
 }
 
 int Dictionary::positivesCount(std::string word) {
-	SqliteYasa::QueryResult queryResult = db.query(
-			"SELECT COUNT(*) AS positives_count FROM positives "
-			"WHERE word = '" + word + "';");
-	return std::stoi(queryResult["positives_count"].front());
+  SqliteYasa::QueryResult queryResult = db.query(
+      "SELECT COUNT(*) AS positives_count FROM positives "
+      "WHERE word = '" +
+      word + "';");
+  return std::stoi(queryResult["positives_count"].front());
 }
 
 int Dictionary::negativesCount() {
-	SqliteYasa::QueryResult queryResult = db.query(
-			"SELECT COUNT(*) AS negatives_count FROM negatives;");
-	return std::stoi(queryResult["negatives_count"].front());
+  SqliteYasa::QueryResult queryResult =
+      db.query("SELECT COUNT(*) AS negatives_count FROM negatives;");
+  return std::stoi(queryResult["negatives_count"].front());
 }
 
 int Dictionary::negativesCount(std::string word) {
-	SqliteYasa::QueryResult queryResult = db.query(
-			"SELECT COUNT(*) AS negatives_count FROM negatives "
-			"WHERE word = '" + word + "';");
-	return std::stoi(queryResult["negatives_count"].front());
+  SqliteYasa::QueryResult queryResult = db.query(
+      "SELECT COUNT(*) AS negatives_count FROM negatives "
+      "WHERE word = '" +
+      word + "';");
+  return std::stoi(queryResult["negatives_count"].front());
 }
-
-
-

--- a/src/Dictionary.h
+++ b/src/Dictionary.h
@@ -6,26 +6,26 @@
 #include "SqliteYasa.h"
 
 class Dictionary {
-public:
-	static Dictionary* getInstance();
+ public:
+  static Dictionary* getInstance();
 
-	void addWord(std::string word, Sentiment sentiment);
+  void addWord(std::string word, Sentiment sentiment);
 
-	int size();
+  int size();
 
-	void reset();
+  void reset();
 
-	int positivesCount();
+  int positivesCount();
 
-	int positivesCount(std::string word);
+  int positivesCount(std::string word);
 
-	int negativesCount();
+  int negativesCount();
 
-	int negativesCount(std::string word);
+  int negativesCount(std::string word);
 
-private:
-	Dictionary();
+ private:
+  Dictionary();
 
-	static Dictionary *instance;
-	SqliteYasa db;
+  static Dictionary* instance;
+  SqliteYasa db;
 };

--- a/src/Sentiment.h
+++ b/src/Sentiment.h
@@ -1,5 +1,3 @@
 #pragma once
 
-enum Sentiment {
-	negative, positive
-};
+enum Sentiment { negative, positive };

--- a/src/SqliteYasa.cc
+++ b/src/SqliteYasa.cc
@@ -5,51 +5,51 @@
 #include <unistd.h>
 #include <stdexcept>
 
-sqlite3* openDb(const char *dbName) {
-	sqlite3 *db;
-	int rst = sqlite3_open(dbName, &db);
-	if (rst) {
-		throw std::runtime_error(sqlite3_errmsg(db));
-	}
-	return db;
+sqlite3 *openDb(const char *dbName) {
+  sqlite3 *db;
+  int rst = sqlite3_open(dbName, &db);
+  if (rst) {
+    throw std::runtime_error(sqlite3_errmsg(db));
+  }
+  return db;
 }
 
 SqliteYasa::SqliteYasa(std::string dbName) {
-	this->dbName = dbName;
-	sqlite3 *db = openDb(this->dbName.c_str());
-	sqlite3_close(db);
+  this->dbName = dbName;
+  sqlite3 *db = openDb(this->dbName.c_str());
+  sqlite3_close(db);
 }
 
 std::string SqliteYasa::getDbPath() {
-	// TODO smarter way to determine pathSize
-	size_t pathSize = 100 + dbName.size();
-	char cwd[pathSize];
-	getcwd(cwd, pathSize);
-	return std::string(cwd) + "/" + dbName;
+  // TODO smarter way to determine pathSize
+  size_t pathSize = 100 + dbName.size();
+  char cwd[pathSize];
+  getcwd(cwd, pathSize);
+  return std::string(cwd) + "/" + dbName;
 }
 
 static int storeQueryResult(void *output, int argc, char **argv,
-		char **colName) {
-	SqliteYasa::QueryResult *result =
-			static_cast<SqliteYasa::QueryResult*>(output);
-	for (int i = 0; i < argc; i++) {
-		result->operator[](colName[i]).push_back(argv[i]);
-	}
-	return 0;
+                            char **colName) {
+  SqliteYasa::QueryResult *result =
+      static_cast<SqliteYasa::QueryResult *>(output);
+  for (int i = 0; i < argc; i++) {
+    result->operator[](colName[i]).push_back(argv[i]);
+  }
+  return 0;
 }
 
 SqliteYasa::QueryResult SqliteYasa::query(std::string sqlQuery) {
-	sqlite3 *db = openDb(dbName.c_str());
-	SqliteYasa::QueryResult queryResult;
-	char *errorMessage;
-	int rst = sqlite3_exec(db, sqlQuery.c_str(), storeQueryResult,
-			static_cast<void*>(&queryResult), &errorMessage);
-	if (rst != SQLITE_OK) {
-		std::string msg = errorMessage;
-		sqlite3_free(errorMessage);
-		sqlite3_close(db);
-		throw std::runtime_error(msg);
-	}
-	sqlite3_close(db);
-	return queryResult;
+  sqlite3 *db = openDb(dbName.c_str());
+  SqliteYasa::QueryResult queryResult;
+  char *errorMessage;
+  int rst = sqlite3_exec(db, sqlQuery.c_str(), storeQueryResult,
+                         static_cast<void *>(&queryResult), &errorMessage);
+  if (rst != SQLITE_OK) {
+    std::string msg = errorMessage;
+    sqlite3_free(errorMessage);
+    sqlite3_close(db);
+    throw std::runtime_error(msg);
+  }
+  sqlite3_close(db);
+  return queryResult;
 }

--- a/src/SqliteYasa.h
+++ b/src/SqliteYasa.h
@@ -5,16 +5,16 @@
 #include <vector>
 
 class SqliteYasa {
-public:
-	SqliteYasa(std::string dbName);
+ public:
+  SqliteYasa(std::string dbName);
 
-	std::string getDbPath();
+  std::string getDbPath();
 
-	// TODO find a better data structure (map is not cache friendly)
-	typedef std::map<std::string, std::vector<std::string>> QueryResult;
+  // TODO find a better data structure (map is not cache friendly)
+  typedef std::map<std::string, std::vector<std::string>> QueryResult;
 
-	QueryResult query(std::string sqlQuery);
+  QueryResult query(std::string sqlQuery);
 
-private:
-	std::string dbName;
+ private:
+  std::string dbName;
 };

--- a/src/fileProcessing.cc
+++ b/src/fileProcessing.cc
@@ -6,74 +6,95 @@
 #include <iterator>
 #include <sstream>
 
-static const std::vector<std::string> stopwords { "a", "about", "above",
-		"above", "across", "after", "afterwards", "again", "against", "all",
-		"almost", "alone", "along", "already", "also", "although", "always",
-		"am", "among", "amongst", "amoungst", "amount", "an", "and", "another",
-		"any", "anyhow", "anyone", "anything", "anyway", "anywhere", "are",
-		"around", "as", "at", "back", "be", "became", "because", "become",
-		"becomes", "becoming", "been", "before", "beforehand", "behind",
-		"being", "below", "beside", "besides", "between", "beyond", "bill",
-		"both", "bottom", "but", "by", "call", "can", "cannot", "cant", "co",
-		"con", "could", "couldnt", "cry", "de", "describe", "detail", "do",
-		"done", "down", "due", "during", "each", "eg", "eight", "either",
-		"eleven", "else", "elsewhere", "empty", "enough", "etc", "even", "ever",
-		"every", "everyone", "everything", "everywhere", "except", "few",
-		"fifteen", "fify", "fill", "find", "fire", "first", "five", "for",
-		"former", "formerly", "forty", "found", "four", "from", "front", "full",
-		"further", "get", "give", "go", "had", "has", "hasnt", "have", "he",
-		"hence", "her", "here", "hereafter", "hereby", "herein", "hereupon",
-		"hers", "herself", "him", "himself", "his", "how", "however", "hundred",
-		"ie", "if", "in", "inc", "indeed", "interest", "into", "is", "it",
-		"its", "itself", "keep", "last", "latter", "latterly", "least", "less",
-		"ltd", "made", "many", "may", "me", "meanwhile", "might", "mill",
-		"mine", "more", "moreover", "most", "mostly", "move", "much", "must",
-		"my", "myself", "name", "namely", "neither", "never", "nevertheless",
-		"next", "nine", "no", "nobody", "none", "noone", "nor", "not",
-		"nothing", "now", "nowhere", "of", "off", "often", "on", "once", "one",
-		"only", "onto", "or", "other", "others", "otherwise", "our", "ours",
-		"ourselves", "out", "over", "own", "part", "per", "perhaps", "please",
-		"put", "rather", "re", "same", "see", "seem", "seemed", "seeming",
-		"seems", "serious", "several", "she", "should", "show", "side", "since",
-		"sincere", "six", "sixty", "so", "some", "somehow", "someone",
-		"something", "sometime", "sometimes", "somewhere", "still", "such",
-		"system", "take", "ten", "than", "that", "the", "their", "them",
-		"themselves", "then", "thence", "there", "thereafter", "thereby",
-		"therefore", "therein", "thereupon", "these", "they", "thick", "thin",
-		"third", "this", "those", "though", "three", "through", "throughout",
-		"thru", "thus", "to", "together", "too", "top", "toward", "towards",
-		"twelve", "twenty", "two", "un", "under", "until", "up", "upon", "us",
-		"very", "via", "was", "we", "well", "were", "what", "whatever", "when",
-		"whence", "whenever", "where", "whereafter", "whereas", "whereby",
-		"wherein", "whereupon", "wherever", "whether", "which", "while",
-		"whither", "who", "whoever", "whole", "whom", "whose", "why", "will",
-		"with", "within", "without", "would", "yet", "you", "your", "yours",
-		"yourself", "yourselves", "the" };
+static const std::vector<std::string> stopwords{
+    "a",         "about",        "above",      "above",      "across",
+    "after",     "afterwards",   "again",      "against",    "all",
+    "almost",    "alone",        "along",      "already",    "also",
+    "although",  "always",       "am",         "among",      "amongst",
+    "amoungst",  "amount",       "an",         "and",        "another",
+    "any",       "anyhow",       "anyone",     "anything",   "anyway",
+    "anywhere",  "are",          "around",     "as",         "at",
+    "back",      "be",           "became",     "because",    "become",
+    "becomes",   "becoming",     "been",       "before",     "beforehand",
+    "behind",    "being",        "below",      "beside",     "besides",
+    "between",   "beyond",       "bill",       "both",       "bottom",
+    "but",       "by",           "call",       "can",        "cannot",
+    "cant",      "co",           "con",        "could",      "couldnt",
+    "cry",       "de",           "describe",   "detail",     "do",
+    "done",      "down",         "due",        "during",     "each",
+    "eg",        "eight",        "either",     "eleven",     "else",
+    "elsewhere", "empty",        "enough",     "etc",        "even",
+    "ever",      "every",        "everyone",   "everything", "everywhere",
+    "except",    "few",          "fifteen",    "fify",       "fill",
+    "find",      "fire",         "first",      "five",       "for",
+    "former",    "formerly",     "forty",      "found",      "four",
+    "from",      "front",        "full",       "further",    "get",
+    "give",      "go",           "had",        "has",        "hasnt",
+    "have",      "he",           "hence",      "her",        "here",
+    "hereafter", "hereby",       "herein",     "hereupon",   "hers",
+    "herself",   "him",          "himself",    "his",        "how",
+    "however",   "hundred",      "ie",         "if",         "in",
+    "inc",       "indeed",       "interest",   "into",       "is",
+    "it",        "its",          "itself",     "keep",       "last",
+    "latter",    "latterly",     "least",      "less",       "ltd",
+    "made",      "many",         "may",        "me",         "meanwhile",
+    "might",     "mill",         "mine",       "more",       "moreover",
+    "most",      "mostly",       "move",       "much",       "must",
+    "my",        "myself",       "name",       "namely",     "neither",
+    "never",     "nevertheless", "next",       "nine",       "no",
+    "nobody",    "none",         "noone",      "nor",        "not",
+    "nothing",   "now",          "nowhere",    "of",         "off",
+    "often",     "on",           "once",       "one",        "only",
+    "onto",      "or",           "other",      "others",     "otherwise",
+    "our",       "ours",         "ourselves",  "out",        "over",
+    "own",       "part",         "per",        "perhaps",    "please",
+    "put",       "rather",       "re",         "same",       "see",
+    "seem",      "seemed",       "seeming",    "seems",      "serious",
+    "several",   "she",          "should",     "show",       "side",
+    "since",     "sincere",      "six",        "sixty",      "so",
+    "some",      "somehow",      "someone",    "something",  "sometime",
+    "sometimes", "somewhere",    "still",      "such",       "system",
+    "take",      "ten",          "than",       "that",       "the",
+    "their",     "them",         "themselves", "then",       "thence",
+    "there",     "thereafter",   "thereby",    "therefore",  "therein",
+    "thereupon", "these",        "they",       "thick",      "thin",
+    "third",     "this",         "those",      "though",     "three",
+    "through",   "throughout",   "thru",       "thus",       "to",
+    "together",  "too",          "top",        "toward",     "towards",
+    "twelve",    "twenty",       "two",        "un",         "under",
+    "until",     "up",           "upon",       "us",         "very",
+    "via",       "was",          "we",         "well",       "were",
+    "what",      "whatever",     "when",       "whence",     "whenever",
+    "where",     "whereafter",   "whereas",    "whereby",    "wherein",
+    "whereupon", "wherever",     "whether",    "which",      "while",
+    "whither",   "who",          "whoever",    "whole",      "whom",
+    "whose",     "why",          "will",       "with",       "within",
+    "without",   "would",        "yet",        "you",        "your",
+    "yours",     "yourself",     "yourselves", "the"};
 
 bool isWord(std::string word) {
-	return word.size() > 0
-			&& std::find(stopwords.begin(), stopwords.end(), word)
-					== stopwords.end();
+  return word.size() > 0 &&
+         std::find(stopwords.begin(), stopwords.end(), word) == stopwords.end();
 }
 
 std::vector<std::string> extractWords(std::string text) {
-	std::vector<std::string> words;
-	auto first = text.begin();
-	while (first != text.end()) {
-		first = std::find_if(first, text.end(), ::isalnum);
-		auto last = std::find_if_not(first, text.end(), ::isalnum);
-		std::string word(first, last);
-		if (isWord(word)) {
-			words.push_back(word);
-		}
-		first = last;
-	}
-	return words;
+  std::vector<std::string> words;
+  auto first = text.begin();
+  while (first != text.end()) {
+    first = std::find_if(first, text.end(), ::isalnum);
+    auto last = std::find_if_not(first, text.end(), ::isalnum);
+    std::string word(first, last);
+    if (isWord(word)) {
+      words.push_back(word);
+    }
+    first = last;
+  }
+  return words;
 }
 
 std::string extractText(std::string filePath) {
-	std::ifstream ifs(filePath);
-	std::stringstream buffer;
-	buffer << ifs.rdbuf();
-	return buffer.str();
+  std::ifstream ifs(filePath);
+  std::stringstream buffer;
+  buffer << ifs.rdbuf();
+  return buffer.str();
 }

--- a/src/fileProcessing.h
+++ b/src/fileProcessing.h
@@ -3,6 +3,6 @@
 #include <string>
 #include <vector>
 
-std::vector<std::string> extractWords(std::string text);
-
 std::string extractText(std::string filePath);
+
+std::vector<std::string> extractWords(std::string text);

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,6 +3,6 @@
 #define VERSION 0.1
 
 int main() {
-	std::cout << "yasa " << VERSION << '\n';
-	return 0;
+  std::cout << "yasa " << VERSION << '\n';
+  return 0;
 }

--- a/tests/DictionaryTest.cc
+++ b/tests/DictionaryTest.cc
@@ -5,77 +5,73 @@
 
 #include "../src/Sentiment.h"
 
-class DictionaryTest: public ::testing::Test {
-protected:
-	virtual void SetUp() {
-		dictionary = Dictionary::getInstance();
-	}
+class DictionaryTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() { dictionary = Dictionary::getInstance(); }
 
-	virtual void TearDown() {
-		dictionary->reset();
-	}
+  virtual void TearDown() { dictionary->reset(); }
 
-	Dictionary *dictionary;
+  Dictionary *dictionary;
 };
 
 TEST_F(DictionaryTest, testSingleton) {
-	Dictionary *d1 = Dictionary::getInstance();
-	Dictionary *d2 = Dictionary::getInstance();
-	ASSERT_EQ(d1, d2);
+  Dictionary *d1 = Dictionary::getInstance();
+  Dictionary *d2 = Dictionary::getInstance();
+  ASSERT_EQ(d1, d2);
 }
 
 TEST_F(DictionaryTest, sizeOfEmptyDictionary) {
-	ASSERT_EQ(dictionary->size(), 0);
+  ASSERT_EQ(dictionary->size(), 0);
 }
 
 TEST_F(DictionaryTest, sizeOfADictionaryWithOneWord) {
-	ASSERT_EQ(dictionary->size(), 0);
-	dictionary->addWord("banana", Sentiment::positive);
-	ASSERT_EQ(dictionary->size(), 1);
+  ASSERT_EQ(dictionary->size(), 0);
+  dictionary->addWord("banana", Sentiment::positive);
+  ASSERT_EQ(dictionary->size(), 1);
 }
 
 TEST_F(DictionaryTest, sizeOfADictionaryTwoWords) {
-	ASSERT_EQ(dictionary->size(), 0);
-	dictionary->addWord("banana", Sentiment::positive);
-	ASSERT_EQ(dictionary->size(), 1);
-	dictionary->addWord("banana", Sentiment::negative);
-	ASSERT_EQ(dictionary->size(), 2);
+  ASSERT_EQ(dictionary->size(), 0);
+  dictionary->addWord("banana", Sentiment::positive);
+  ASSERT_EQ(dictionary->size(), 1);
+  dictionary->addWord("banana", Sentiment::negative);
+  ASSERT_EQ(dictionary->size(), 2);
 }
 
 TEST_F(DictionaryTest, positivesCount) {
-	ASSERT_EQ(dictionary->positivesCount(), 0);
-	dictionary->addWord("banana", Sentiment::positive);
-	ASSERT_EQ(dictionary->positivesCount(), 1);
-	dictionary->addWord("banana", Sentiment::positive);
-	dictionary->addWord("banana", Sentiment::positive);
-	ASSERT_EQ(dictionary->positivesCount(), 3);
+  ASSERT_EQ(dictionary->positivesCount(), 0);
+  dictionary->addWord("banana", Sentiment::positive);
+  ASSERT_EQ(dictionary->positivesCount(), 1);
+  dictionary->addWord("banana", Sentiment::positive);
+  dictionary->addWord("banana", Sentiment::positive);
+  ASSERT_EQ(dictionary->positivesCount(), 3);
 }
 
 TEST_F(DictionaryTest, negativesCount) {
-	ASSERT_EQ(dictionary->negativesCount(), 0);
-	dictionary->addWord("banana", Sentiment::negative);
-	ASSERT_EQ(dictionary->negativesCount(), 1);
-	dictionary->addWord("banana", Sentiment::negative);
-	dictionary->addWord("banana", Sentiment::negative);
-	ASSERT_EQ(dictionary->negativesCount(), 3);
+  ASSERT_EQ(dictionary->negativesCount(), 0);
+  dictionary->addWord("banana", Sentiment::negative);
+  ASSERT_EQ(dictionary->negativesCount(), 1);
+  dictionary->addWord("banana", Sentiment::negative);
+  dictionary->addWord("banana", Sentiment::negative);
+  ASSERT_EQ(dictionary->negativesCount(), 3);
 }
 
 TEST_F(DictionaryTest, positivesCountOfAWord) {
-	ASSERT_EQ(dictionary->positivesCount("banana"), 0);
-	dictionary->addWord("banana", Sentiment::positive);
-	ASSERT_EQ(dictionary->positivesCount("banana"), 1);
-	dictionary->addWord("banana", Sentiment::positive);
-	dictionary->addWord("banana", Sentiment::positive);
-	ASSERT_EQ(dictionary->positivesCount("banana"), 3);
-	ASSERT_EQ(dictionary->positivesCount("apple"), 0);
+  ASSERT_EQ(dictionary->positivesCount("banana"), 0);
+  dictionary->addWord("banana", Sentiment::positive);
+  ASSERT_EQ(dictionary->positivesCount("banana"), 1);
+  dictionary->addWord("banana", Sentiment::positive);
+  dictionary->addWord("banana", Sentiment::positive);
+  ASSERT_EQ(dictionary->positivesCount("banana"), 3);
+  ASSERT_EQ(dictionary->positivesCount("apple"), 0);
 }
 
 TEST_F(DictionaryTest, negativesCountOfAWord) {
-	ASSERT_EQ(dictionary->negativesCount("banana"), 0);
-	dictionary->addWord("banana", Sentiment::negative);
-	ASSERT_EQ(dictionary->negativesCount("banana"), 1);
-	dictionary->addWord("banana", Sentiment::negative);
-	dictionary->addWord("banana", Sentiment::negative);
-	ASSERT_EQ(dictionary->negativesCount("banana"), 3);
-	ASSERT_EQ(dictionary->negativesCount("apple"), 0);
+  ASSERT_EQ(dictionary->negativesCount("banana"), 0);
+  dictionary->addWord("banana", Sentiment::negative);
+  ASSERT_EQ(dictionary->negativesCount("banana"), 1);
+  dictionary->addWord("banana", Sentiment::negative);
+  dictionary->addWord("banana", Sentiment::negative);
+  ASSERT_EQ(dictionary->negativesCount("banana"), 3);
+  ASSERT_EQ(dictionary->negativesCount("apple"), 0);
 }

--- a/tests/SentimentTest.cc
+++ b/tests/SentimentTest.cc
@@ -1,14 +1,15 @@
+#include "../src/Sentiment.h"
+
 #include <gtest/gtest.h>
-#include <Sentiment.h>
 
 TEST(sentimentTest, positiveDifferentFromNegative) {
-	ASSERT_NE(Sentiment::positive, Sentiment::negative);
+  ASSERT_NE(Sentiment::positive, Sentiment::negative);
 }
 
 TEST(sentimentTest, positiveEqualsToPositive) {
-	ASSERT_EQ(Sentiment::positive, Sentiment::positive);
+  ASSERT_EQ(Sentiment::positive, Sentiment::positive);
 }
 
 TEST(sentimentTest, positiveEqualsToNegative) {
-	ASSERT_EQ(Sentiment::negative, Sentiment::negative);
+  ASSERT_EQ(Sentiment::negative, Sentiment::negative);
 }

--- a/tests/SqliteYasaTest.cc
+++ b/tests/SqliteYasaTest.cc
@@ -8,45 +8,46 @@
 #include <vector>
 
 TEST(yasaDbTest, throwRuntimeErrorWhenFilenameIsInvalid) {
-	ASSERT_THROW(SqliteYasa("/"), std::runtime_error);
+  ASSERT_THROW(SqliteYasa("/"), std::runtime_error);
 }
 
 TEST(yasaDbTest, getDbPath) {
-	SqliteYasa db = SqliteYasa("test.db");
-	std::string path = db.getDbPath();
-	ASSERT_EQ(path.front(), '/');
-	ASSERT_NE(path.rfind("test.db"), std::string::npos);
-	std::ifstream infile(path);
-	ASSERT_TRUE(infile.good());
+  SqliteYasa db = SqliteYasa("test.db");
+  std::string path = db.getDbPath();
+  ASSERT_EQ(path.front(), '/');
+  ASSERT_NE(path.rfind("test.db"), std::string::npos);
+  std::ifstream infile(path);
+  ASSERT_TRUE(infile.good());
 }
 
 TEST(yasaDbTest, testDbFileCreation) {
-	SqliteYasa db = SqliteYasa("test.db");
-	std::string path = db.getDbPath();
-	std::ifstream infile(path);
-	ASSERT_TRUE(infile.good());
+  SqliteYasa db = SqliteYasa("test.db");
+  std::string path = db.getDbPath();
+  std::ifstream infile(path);
+  ASSERT_TRUE(infile.good());
 }
 
 TEST(yasaDbTest, wrongSqlSyntaxThrowRuntimeError) {
-	SqliteYasa db = SqliteYasa("test.db");
-	ASSERT_THROW(db.query("WRONG SQL SYNTAX"), std::runtime_error);
+  SqliteYasa db = SqliteYasa("test.db");
+  ASSERT_THROW(db.query("WRONG SQL SYNTAX"), std::runtime_error);
 }
 
 TEST(yasaDbTest, testSimpleQueries) {
-	SqliteYasa db = SqliteYasa("test.db");
-	db.query("CREATE TABLE testTable("
-			"id int PRIMARY KEY NOT NULL,"
-			"name VARCHAR(30) NOT NULL);");
-	SqliteYasa::QueryResult result = db.query(
-			"SELECT name FROM sqlite_master WHERE type = 'table';");
-	ASSERT_EQ(result["name"], std::vector<std::string> { "testTable" });
+  SqliteYasa db = SqliteYasa("test.db");
+  db.query(
+      "CREATE TABLE testTable("
+      "id int PRIMARY KEY NOT NULL,"
+      "name VARCHAR(30) NOT NULL);");
+  SqliteYasa::QueryResult result =
+      db.query("SELECT name FROM sqlite_master WHERE type = 'table';");
+  ASSERT_EQ(result["name"], std::vector<std::string>{"testTable"});
 
-	db.query("INSERT INTO testTable(id, name) VALUES(1000, 'John');");
-	result = db.query("SELECT * FROM testTable WHERE id = 1000");
-	ASSERT_EQ(result["id"], std::vector<std::string> { "1000" });
-	ASSERT_EQ(result["name"], std::vector<std::string> { "John" });
+  db.query("INSERT INTO testTable(id, name) VALUES(1000, 'John');");
+  result = db.query("SELECT * FROM testTable WHERE id = 1000");
+  ASSERT_EQ(result["id"], std::vector<std::string>{"1000"});
+  ASSERT_EQ(result["name"], std::vector<std::string>{"John"});
 
-	db.query("DROP TABLE TESTTABLE;");
-	result = db.query("SELECT name FROM sqlite_master WHERE type = 'table';");
-	ASSERT_EQ(result["name"], std::vector<std::string> { });
+  db.query("DROP TABLE TESTTABLE;");
+  result = db.query("SELECT name FROM sqlite_master WHERE type = 'table';");
+  ASSERT_EQ(result["name"], std::vector<std::string>{});
 }

--- a/tests/fileProcessingTest.cc
+++ b/tests/fileProcessingTest.cc
@@ -5,34 +5,33 @@
 #include <vector>
 
 TEST(fileProcessingTest, emptyTest) {
-	std::vector<std::string> actual = extractWords("");
-	std::vector<std::string> expected { };
-	ASSERT_EQ(actual, expected);
+  std::vector<std::string> actual = extractWords("");
+  std::vector<std::string> expected{};
+  ASSERT_EQ(actual, expected);
 }
 
 TEST(fileProcessingTest, oneLetterText) {
-	std::vector<std::string> actual = extractWords("O");
-	std::vector<std::string> expected { "O" };
-	ASSERT_EQ(actual, expected);
+  std::vector<std::string> actual = extractWords("O");
+  std::vector<std::string> expected{"O"};
+  ASSERT_EQ(actual, expected);
 }
 
 TEST(fileProcessingTest, extractWordsWithSpaces) {
-	std::vector<std::string> actual = extractWords(
-			"  yasa is   the\nbest\r\nsoftware\tin\vthe\fworld   ");
-	std::vector<std::string> expected = { "yasa", "best", "software", "world" };
-	ASSERT_EQ(actual, expected);
+  std::vector<std::string> actual =
+      extractWords("  yasa is   the\nbest\r\nsoftware\tin\vthe\fworld   ");
+  std::vector<std::string> expected = {"yasa", "best", "software", "world"};
+  ASSERT_EQ(actual, expected);
 }
 
 TEST(fileProcessingTest, extractWordsWithPunctuation) {
-	std::vector<std::string> actual = extractWords(
-			"  yasa. is,the!best:software;;in the' world?   ");
-	std::vector<std::string> expected = { "yasa", "best", "software", "world" };
-	ASSERT_EQ(actual, expected);
+  std::vector<std::string> actual =
+      extractWords("  yasa. is,the!best:software;;in the' world?   ");
+  std::vector<std::string> expected = {"yasa", "best", "software", "world"};
+  ASSERT_EQ(actual, expected);
 }
 
 TEST(fileProcessingTest, extractTextFromFile) {
-	std::string actual = extractText("./resources/test.txt");
-	std::string expected = "THIS IS A LINE\nTHIS IS ANOTHER LINE";
-	ASSERT_EQ(actual, expected);
+  std::string actual = extractText("./resources/test.txt");
+  std::string expected = "THIS IS A LINE\nTHIS IS ANOTHER LINE";
+  ASSERT_EQ(actual, expected);
 }
-

--- a/tests/runAllTests.cc
+++ b/tests/runAllTests.cc
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
 int main(int argc, char **argv) {
-	::testing::InitGoogleTest(&argc, argv);
-	return RUN_ALL_TESTS();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Thanks to the Eclipse plugin CppStyle, now the code can be reformatted with clang-format.

Since I have not created any `.clang-format` file, when `ctrl+shift+f` is pressed the code is formatted with the [Google style](https://google.github.io/styleguide/cppguide.html), that seems good to me.